### PR TITLE
Updated Parameters to Account for Stress Testing

### DIFF
--- a/viralrecall/proteins.py
+++ b/viralrecall/proteins.py
@@ -65,7 +65,7 @@ def search_with_pyhmmer(proteins: easel.TextSequenceBlock,
 	digseqs = easel.DigitalSequenceBlock(amino, proteins.digitize(amino))
 	
 	with plan7.HMMFile(hmm_path) as hmm_file:
-		hits = list(hmmer.hmmsearch(hmm_file, digseqs, E=evalue))
+		hits = list(hmmer.hmmsearch(hmm_file, digseqs, E=evalue, cpus = 4))
 	return hits	
 	
 		

--- a/viralrecall/viralrecall.py
+++ b/viralrecall/viralrecall.py
@@ -242,7 +242,7 @@ def main(argv=None):
 			newinput = input / i
 			arg_list.append((newinput, out_base, database, window, phagesize, minscore, evalue, minhit)) 
 		
-		with mp.Pool(cpus) as pool:
+		with mp.Pool(cpus, maxtasksperchild = 1) as pool:
 			pool.starmap(run_program, arg_list)
 			print(f"Finished running ViralRecall on all files in {input} and the output has been deposited in {project}")
 


### PR DESCRIPTION
Fix: Set maxtasksperchild to one and capped hmmsearch cpus to four to prevent deadlock on large inputs.